### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto eol=lf
+*.{cmd,[cC][mM][dD]} text eol=crlf
+*.{bat,[bB][aA][tT]} text eol=crlf


### PR DESCRIPTION
This pull request includes a small change to the `.gitattributes` file. The change ensures consistent end-of-line (EOL) settings for different file types, specifying LF for text files and CRLF for command and batch files.